### PR TITLE
Bump log4j-core from 2.6.1 to 2.13.2 in /modules/cli-module

### DIFF
--- a/modules/cli-module/pom.xml
+++ b/modules/cli-module/pom.xml
@@ -117,7 +117,7 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
-            <version>2.6.1</version>
+            <version>2.13.2</version>
             <scope>runtime</scope>
         </dependency>
 


### PR DESCRIPTION
Bumps log4j-core from 2.6.1 to 2.13.2.

---
updated-dependencies:
- dependency-name: org.apache.logging.log4j:log4j-core
  dependency-type: direct:production
...

Signed-off-by: dependabot[bot] <support@github.com>